### PR TITLE
Remove redundant -y from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN set -e; \
 	apt-get -qq update; \
 	\
 	# Install required packages
-	apt-get install -y -qq --no-install-suggests --no-install-recommends \
+	apt-get install -qq --no-install-suggests --no-install-recommends \
 		software-properties-common \
 		python3-software-properties \
 		git \


### PR DESCRIPTION
The `-y` option is implied automatically when `-qq` is used, due to `-qq` setting the 'quiet level' to `2`.