### PR TITLE
Update README to remove misleading `ssh://` prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ docker-compose build
     1. Create a `secrets.env` file in the `mybb-build` directory with the data repository URL variable:
 
     ```
-    INPUT_FILES_REPOSITORY=ssh://git@github.com/mybb/...
+    INPUT_FILES_REPOSITORY=git@github.com/mybb/...
     ```
 
     2. Create a Deploy key and add/ask to add it to the data repository and place the private key file (`id_ed25519`, `id_rsa`, etc.) in `secrets/`. Files within this directory will be copied into the container and configured as a SSH key to use when pulling data in the `remote-data` task.


### PR DESCRIPTION
Having an `ssh://` prefix on the `INPUT_FILES_REPOSITORY` leads to confusing errors like:

```
# github.com:22 SSH-2.0-libssh_0.7.0
Buildfile: /home/user/build.xml
 [property] Loading /home/user/input/build.properties

MyBB > remote-data:

    [mkdir] Created dir: /home/user/build/git

BUILD FAILED
/home/user/build.xml:115:12: /home/user/build.xml:122:162: Task exited with code 128

Total time: 0.0600 seconds
```