### PR TITLE
README.md and .gitignore updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 /build
-/secrets
-/sources/patch
-/sources/previous-clean-source
-/sources/raw-source
+/input/source/
+/input/previous-source/
+/input/patches/
+/input/package-addendum/
+/output
 /phing.phar
 /phing-latest.phar
+/secrets
 /secrets.env

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A Docker image [is built](https://github.com/mybb/mybb-build/blob/master/Dockerf
      1. Create a `secrets.env` file in the main directory with the data repository URL variable:
 
         ```
-        INPUT_FILES_REPOSITORY=git@github.com/mybb/...
+        INPUT_FILES_REPOSITORY=git@github.com:mybb/additional-input-files.git
         ```
 
      2. Create a Deploy key and add/ask to add it to the data repository and place the private key file (`id_ed25519`, `id_rsa`, etc.) in `secrets/`. Files within this directory will be copied into the container and configured as a SSH key to use when pulling data in the `remote-data` task.


### PR DESCRIPTION
Looks like some directories were moved but .gitignore wasn't changed.

Updated example for `INPUT_FILES_REPOSITORY` in README since copy-paste of `git@github.com/mybb/` may lead to the mistake of using `git@github.com/mybb/mybb.git` which isn't correct and gives a 128 error code which isn't very descriptive of the problem! Better to just have a good example ;)